### PR TITLE
Update RNVoipPushNotificationManager.m

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -212,7 +212,6 @@ dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), di
 });
 }
 
-
 + (void)addCompletionHandler:(NSString *)uuid completionHandler:(RNVoipPushNotificationCompletion)completionHandler
 {
     self.completionHandlers[uuid] = completionHandler;

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -205,10 +205,13 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 
 - (void)handleRemoteNotificationReceived:(NSNotification *)notification
 {
-    NSLog(@"[RNVoipPushNotificationManager] handleRemoteNotificationReceived notification.userInfo = %@", notification.userInfo);
+dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+     NSLog(@"[RNVoipPushNotificationManager] handleRemoteNotificationReceived notification.userInfo = %@", notification.userInfo);
     [_bridge.eventDispatcher sendDeviceEventWithName:@"voipRemoteNotificationReceived"
                                                 body:notification.userInfo];
+});
 }
+
 
 + (void)addCompletionHandler:(NSString *)uuid completionHandler:(RNVoipPushNotificationCompletion)completionHandler
 {


### PR DESCRIPTION
Fix error, when VoipNotificaiton.addEventListener('notification') is not called, when app was terminated and opened on rnCallKeep call. 